### PR TITLE
Removed dependency to the UXTOManager

### DIFF
--- a/core/app/app.go
+++ b/core/app/app.go
@@ -15,7 +15,7 @@ import (
 
 var (
 	// Version of the app.
-	Version = "0.1.1"
+	Version = "0.1.2"
 
 	// configs
 	appConfig = configuration.New()

--- a/pkg/migrator/service.go
+++ b/pkg/migrator/service.go
@@ -8,7 +8,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/gohornet/hornet/pkg/common"
-	"github.com/gohornet/hornet/pkg/model/utxo"
 	"github.com/gohornet/hornet/pkg/utils"
 	"github.com/iotaledger/hive.go/events"
 	"github.com/iotaledger/hive.go/syncutils"
@@ -131,7 +130,7 @@ func (s *MigratorService) PersistState(sendingReceipt bool) error {
 // otherwise the state is loaded from file.
 // The optional utxoManager is used to validate the initialized state against the DB.
 // InitState must be called before Start.
-func (s *MigratorService) InitState(msIndex *uint32, utxoManager *utxo.Manager) error {
+func (s *MigratorService) InitState(msIndex *uint32) error {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
@@ -161,17 +160,18 @@ func (s *MigratorService) InitState(msIndex *uint32, utxoManager *utxo.Manager) 
 		return fmt.Errorf("%w: latest migrated at index must not be zero", ErrInvalidState)
 	}
 
-	if utxoManager != nil {
-		highestMigratedAtIndex, err := utxoManager.SearchHighestReceiptMigratedAtIndex()
-		if err != nil {
-			return fmt.Errorf("unable to determine highest migrated at index: %w", err)
-		}
-		// if highestMigratedAtIndex is zero no receipt in the DB, so we cannot do sanity checks
-		if highestMigratedAtIndex > 0 && highestMigratedAtIndex != state.LatestMigratedAtIndex {
-			return fmt.Errorf("state receipt does not match highest receipt in database: state: %d, database: %d",
-				state.LatestMigratedAtIndex, highestMigratedAtIndex)
-		}
-	}
+	//TODO: read this from the latest milestone metadata (https://github.com/gohornet/inx-coordinator/issues/2)
+	//if utxoManager != nil {
+	//	highestMigratedAtIndex, err := utxoManager.SearchHighestReceiptMigratedAtIndex()
+	//	if err != nil {
+	//		return fmt.Errorf("unable to determine highest migrated at index: %w", err)
+	//	}
+	//	// if highestMigratedAtIndex is zero no receipt in the DB, so we cannot do sanity checks
+	//	if highestMigratedAtIndex > 0 && highestMigratedAtIndex != state.LatestMigratedAtIndex {
+	//		return fmt.Errorf("state receipt does not match highest receipt in database: state: %d, database: %d",
+	//			state.LatestMigratedAtIndex, highestMigratedAtIndex)
+	//	}
+	//}
 
 	s.state = state
 	return nil

--- a/pkg/migrator/service_test.go
+++ b/pkg/migrator/service_test.go
@@ -101,11 +101,11 @@ func newTestService(t *testing.T, msIndex uint32, maxEntries int) (*migrator.Mig
 
 	if msIndex > 0 {
 		// bootstrap
-		err := s.InitState(&msIndex, nil)
+		err := s.InitState(&msIndex)
 		require.NoError(t, err)
 	} else {
 		// load from state
-		err := s.InitState(nil, nil)
+		err := s.InitState(nil)
 		require.NoError(t, err)
 	}
 

--- a/plugin/migrator/plugin.go
+++ b/plugin/migrator/plugin.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/gohornet/hornet/pkg/common"
 	validator "github.com/gohornet/hornet/pkg/model/migrator"
-	"github.com/gohornet/hornet/pkg/model/utxo"
 	"github.com/gohornet/hornet/pkg/node"
 	"github.com/gohornet/hornet/pkg/shutdown"
 	"github.com/gohornet/inx-coordinator/pkg/daemon"
@@ -55,7 +54,6 @@ var (
 
 type dependencies struct {
 	dig.In
-	UTXOManager     *utxo.Manager
 	AppConfig       *configuration.Configuration `name:"appConfig"`
 	MigratorService *migrator.MigratorService
 	ShutdownHandler *shutdown.ShutdownHandler
@@ -119,7 +117,7 @@ func configure() {
 		msIndex = startIndex
 	}
 
-	if err := deps.MigratorService.InitState(msIndex, deps.UTXOManager); err != nil {
+	if err := deps.MigratorService.InitState(msIndex); err != nil {
 		Plugin.LogFatalf("failed to initialize migrator: %s", err)
 	}
 }


### PR DESCRIPTION
- This makes us skip a migrator.state check against the ledger that is planned to be removed/moved anyway (see #2)