### PR TITLE
Prevents issuance of milestones with same timestamp

### DIFF
--- a/core/coordinator/component.go
+++ b/core/coordinator/component.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	flag "github.com/spf13/pflag"
@@ -345,6 +346,12 @@ func run() error {
 
 			case <-nextMilestoneSignal:
 				var milestoneTips iotago.BlockIDs
+
+				// skip signal to prevent milestone issuance with same timestamp
+				if deps.Coordinator.State().LatestMilestoneTime.Unix() == time.Now().Unix() {
+					CoreComponent.LogWarn("skipping milestone signal due to too fast ticker")
+					continue
+				}
 
 				// issue a new checkpoint right in front of the milestone
 				checkpointTips, err := deps.Selector.SelectTips(1)


### PR DESCRIPTION
When the main coordinator loop gets a signal to issue a milestone, we now check whether the current second-resolution unix time is the same as the last issued milestone's timestamp and if so, skip the signal. This can happen in cases where it takes longer to issue a milestone while the ticker is already running to send the next signal, causing it to fire right away within a second bound of when the last milestone got issued.

Fixes #22 