### PR TITLE
Do not accept new blocks if no milestone was issued for a longer time

### DIFF
--- a/core/coordinator/params.go
+++ b/core/coordinator/params.go
@@ -14,9 +14,10 @@ type Quorum struct {
 }
 
 type ParametersCoordinator struct {
-	StateFilePath string        `default:"coordinator.state" usage:"the path to the state file of the coordinator"`
-	Interval      time.Duration `default:"5s" usage:"the interval milestones are issued"`
-	Signing       struct {
+	StateFilePath    string        `default:"coordinator.state" usage:"the path to the state file of the coordinator"`
+	Interval         time.Duration `default:"5s" usage:"the interval milestones are issued"`
+	MilestoneTimeout time.Duration `default:"30s" usage:"the duration after which an event is triggered if no new milestones are received"`
+	Signing          struct {
 		Provider      string        `default:"local" usage:"the signing provider the coordinator uses to sign a milestone (local/remote)"`
 		RemoteAddress string        `default:"localhost:12345" usage:"the address of the remote signing provider (insecure connection!)"`
 		RetryTimeout  time.Duration `default:"2s" usage:"defines the timeout between signing retries"`


### PR DESCRIPTION
This PR adds a ticker that fires events in case no new milestones were seen for a longer time.

The event stops the selector from accepting new blocks for the tipselection.
This is needed to avoid out of memory errors in case the coordinator is unable to issue new milestones (e.g. the node is doing long running snapshots).